### PR TITLE
Problem 21 Incorrect Result for Min Product Sold

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -268,7 +268,7 @@ class Products(ViewSet):
 
         if number_sold is not None:
             def sold_filter(product):
-                if product.number_sold <= int(number_sold):
+                if product.number_sold >= int(number_sold):
                     return True
                 return False
 


### PR DESCRIPTION
Clients can request a list of products that have sold at least the specified number of items using the following URL scheme.

http://localhost:8000/products?number_sold=20

This should return products that have been sold 20+ times. This feature is currently not working.

## Changes

- Changed the <= into a >= in the product.py view inside of the number_sold conditional within the product list

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

POST `/products` Creates a new product

```json
{
        "id": 45,
        "name": "Corvette",
        "price": 795.8,
        "number_sold": 1,
        "description": "1987 Chevrolet",
        "quantity": 2,
        "created_date": "2019-10-07",
        "location": "Ueno",
        "image_path": null,
        "average_rating": 0
    },
    {
        "id": 50,
        "name": "Escalade EXT",
        "price": 926.92,
        "number_sold": 2,
        "description": "2008 Cadillac",
        "quantity": 2,
        "created_date": "2019-02-01",
        "location": "Lokavec",
        "image_path": null,
        "average_rating": 3.25
    }
```

**Response**

HTTP/1.1 201 OK

```json
{
        "id": 50,
        "name": "Escalade EXT",
        "price": 926.92,
        "number_sold": 2,
        "description": "2008 Cadillac",
        "quantity": 2,
        "created_date": "2019-02-01",
        "location": "Lokavec",
        "image_path": null,
        "average_rating": 3.25
    }
```

## Testing

Serve and run postman and test getting products by quantity sold is functioning correctly as >= to the value you set after the equal sign

- [ ] Seed database
- [ ] Run test suite



## Related Issues

- Fixes #21 
