### PR TITLE
Problem 22 Same User Profile Returned

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -81,7 +81,7 @@ class Profile(ViewSet):
             }
         """
         try:
-            current_user = Customer.objects.get(user=4)
+            current_user = Customer.objects.get(user=request.auth.user)
             current_user.recommends = Recommendation.objects.filter(recommender=current_user)
 
             serializer = ProfileSerializer(


### PR DESCRIPTION
When an authenticated client submits a GET request to the /profile resource, an incorrect user profile is returned. Additionally, the same user profile is returned regardless of the authentication token provided.
## Changes

- Changed the  current_user to pull from the auth.user rather than just user 4

## Testing

Seed database and run postman and check that the current user list shows the correct user and not just user 4

- [ ] Seed database
- [ ] Run test suite


## Related Issues

- Fixes #22 