### PR TITLE
Problem 20 Cannot Remove Item From Cart

### DIFF
--- a/bangazonapi/views/lineitem.py
+++ b/bangazonapi/views/lineitem.py
@@ -77,6 +77,7 @@ class LineItems(ViewSet):
         try:
             customer = Customer.objects.get(user=request.auth.user)
             order_product = OrderProduct.objects.get(pk=pk, order__customer=customer)
+            order_product.delete()
 
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 


### PR DESCRIPTION
Customers are complaining that they can't remove an item from the cart after it has been added.

When the client performs a DELETE request to the /lineitems/n resource, it should remove the specified item from the user's cart.


## Changes

- Changed the order_product in the destroy for the lineitem view to have a .delete() in order to get rid of the cart items

## Testing

seed database and run server to get on postman and check that the contents of the cart gets deleted. use the get method and post method to the cart as needed for testing

- [ ] Seed database
- [ ] Run test suite



## Related Issues

- Fixes #20 